### PR TITLE
Add more Instagram post info and log fetch results

### DIFF
--- a/src/components/InstagramPosts.jsx
+++ b/src/components/InstagramPosts.jsx
@@ -12,13 +12,32 @@ const DEFAULT_URLS = [
 async function fetchPost(url) {
   const res = await fetch(`https://r.jina.ai/${url}`);
   const text = await res.text();
+
   const imageMatch = text.match(/https:\/\/[^"']*cdninstagram[^"']*/);
   const captionMatch = text.match(/Title: .*? on Instagram: "([^"]+)/);
-  return {
+
+  // username in format [username](https://www.instagram.com/username/)
+  const usernameMatch = text.match(/\[([A-Za-z0-9_.]+)\]\(https:\/\/www\.instagram\.com\/\1\//);
+
+  // likes count in format [123 likes](https://www.instagram.com/p/...)
+  const likesMatch = text.match(/\[(\d+(?:,\d+)*) likes\]/);
+
+  // Optional original audio link
+  const audioMatch = text.match(/\[Original audio\]\(([^)]+)\)/);
+
+  const post = {
     url,
     image: imageMatch ? imageMatch[0] : null,
     caption: captionMatch ? captionMatch[1] : "",
+    username: usernameMatch ? usernameMatch[1] : "",
+    likes: likesMatch ? parseInt(likesMatch[1].replace(/,/g, ""), 10) : 0,
+    audio: audioMatch ? audioMatch[1] : null,
   };
+
+  // Log each fetched post for debugging purposes
+  console.log("Fetched", post);
+
+  return post;
 }
 
 export default function InstagramPosts({ posts = DEFAULT_URLS }) {
@@ -27,6 +46,7 @@ export default function InstagramPosts({ posts = DEFAULT_URLS }) {
   useEffect(() => {
     async function load() {
       const results = await Promise.all(posts.map(fetchPost));
+      console.log("Fetched posts", results);
       setData(results);
     }
     load();


### PR DESCRIPTION
## Summary
- enhance `fetchPost` to parse username, likes and audio URL
- log individual fetched posts and all results

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68557b5f242483239f843e3b735aeed6