### PR TITLE
Allow overflowing sections

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -121,7 +121,8 @@ h6 {
 }
 
 section {
-  height: 100vh;
+  min-height: 100vh;
+  height: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -131,5 +132,5 @@ section {
   top: 0;
   right: 0;
   left: 0;
-  overflow: auto;
+  overflow: visible;
 }


### PR DESCRIPTION
## Summary
- allow sections to expand with `min-height` instead of `height`
- set section overflow to `visible`

## Testing
- `npm run lint` *(fails: Parsing error in public/embed.js)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6856c2333b688323a7e5cda5a2ec3ae6