### PR TITLE
Fix scroll snap

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -5,6 +5,9 @@
   flex: 1;
   width: 100%;
   height: 100%;
+  /* Enable vertical scroll snapping for all sections */
+  overflow-y: auto;
+  scroll-snap-type: y mandatory;
 }
 
 /* ============== GLOBAL STYLES ============== */

--- a/src/index.css
+++ b/src/index.css
@@ -133,4 +133,6 @@ section {
   right: 0;
   left: 0;
   overflow: visible;
+  /* Snap each section to the top of the viewport */
+  scroll-snap-align: start;
 }


### PR DESCRIPTION
## Summary
- enable `scroll-snap-type` on the root container
- snap each section to the viewport top

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68573c0fb50c832383accc3c14978bb6